### PR TITLE
Editing download.ts changing filename to random

### DIFF
--- a/src/lib/download.ts
+++ b/src/lib/download.ts
@@ -37,7 +37,7 @@ export const downloadYT = async (url: string): Promise<Buffer> => {
  * @param filename the file to save to
  * @returns filename
  */
-export const downloadYTAndSave = async (url: string, filename = './spotifydl-core.mp3'): Promise<string> => {
+export const downloadYTAndSave = async (url: string, filename = (Math.random() + 1).toString(36).substring(7) + '.mp3'): Promise<string> => {
     const audio = await downloadYT(url)
     try {
         await writeFile(filename, audio)


### PR DESCRIPTION
When **downloading** a spotify **playlist** some song where not corectly **download and writted** into file (certain _file had 0 Bytes_)

```
export const downloadSpotifyPlaylist = async (playlist: MyPlaylist) => {
    console.log(`⏬ Downloading playlist ${playlist.title}...`);
    const buffers = await spotify.downloadPlaylist(playlist.url);
    let i = 0;
    for (const buffer of buffers) {
        const song = playlist.songs[i];
        // if buffer is empty that's a string that was a string returned and not a buffer
        if (buffer.length === 0) {
            console.log(song.title);
            console.log(typeof buffer);
        }
        fs.writeFileSync(`${DOWNLOAD_PATH}${clearText(song.title)}.mp3`, buffer);
        i++;
    }
    console.log(`⏬ Download playlist ${playlist.title} completed!`);
}
```
I think that is due to the **string returned** in [https://github.com/AlenVelocity/spotifydl-core/blob/3decdff46c5ad0aaf07951f17035def379a11b96/src/lib/download.ts#L40](this function) or that the name was the same so the **temp file erase themself**

I edit [https://github.com/AlenVelocity/spotifydl-core/blob/3decdff46c5ad0aaf07951f17035def379a11b96/src/lib/download.ts#L40](this line) _changing filename to random_ to **avoid file erasing and string return**

I've **tested** my change and i think there's not other problem

So if you can **accept this PR** and **merge** it with your code it will be a good **bug fix**